### PR TITLE
chore: move `google/protobuf` requirement to dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,15 @@
     }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.1"
+  },
+  "require-dev": {
     "google/protobuf": "^3.22 || ^4.0"
   },
   "suggest": {
-    "google/common-protos": "Required for Temporal API"
+    "google/common-protos": "Required for Temporal API",
+    "ext-protobuf": "Protobuf codec support",
+    "google/protobuf": "(^3.22) Protobuf codec support"
   },
   "conflict": {
     "temporal/sdk": "<2.9.0"


### PR DESCRIPTION
Hello.
Trying to do the same as in the repository https://github.com/roadrunner-php/goridge - `google/protobuf` is removed from `require_dev` and added to `suggest` `ext-protobuf` as well. The purpose is not to install `google/protobuf` when `ext-protobuf` already installed.

However, I can not add an exception throw same as here: https://github.com/roadrunner-php/goridge/blob/8fe68b0c871862f9ec852659de1cc7c1a68b783f/src/RPC/Codec/ProtobufCodec.php#L26

All class are autogenerated, trying to find out where to make an user-friendly exception if nothing is installed. Need assistance c:

cc @Kaspiman

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Protobuf codec in the development environment.
- **Documentation**
	- Improved clarity and organization of dependency requirements in the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->