### PR TITLE
Update `google/protobuf` version constraint to support `5.34.0`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "google/protobuf": "^4.31.1"
+    "google/protobuf": "^4.31.1||^5.34.0"
   },
   "suggest": {
     "google/common-protos": "Required for Temporal API"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended compatibility with multiple versions of the Protocol Buffers library to improve deployment flexibility and stability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->